### PR TITLE
fix: sanitize ALLOWED_FRAME_ANCESTORS so a stray newline can't 502 every response

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -53,8 +53,10 @@ app = FastAPI(
 )
 
 # CORS — restrict to CRM domain(s) when configured, fall back to CORS_ORIGINS setting.
+# Strip each origin: env values pasted into hosting dashboards often carry stray
+# whitespace/newlines, which would silently never match a real Origin header.
 if settings.cors_origins != "*":
-    _cors_origins = settings.cors_origins.split(",")
+    _cors_origins = [o.strip() for o in settings.cors_origins.split(",") if o.strip()]
 elif settings.allowed_frame_ancestors:
     _cors_origins = settings.allowed_frame_ancestors.split()
 else:
@@ -75,12 +77,17 @@ if settings.allowed_frame_ancestors:
     @app.middleware("http")
     async def frame_embedding_headers(request, call_next):
         response = await call_next(request)
-        ancestors = settings.allowed_frame_ancestors
+        # Collapse any stray whitespace/newlines from the env value. A trailing
+        # newline (easy to introduce when pasting into a hosting dashboard) makes
+        # the header value illegal, and uvicorn raises "Invalid HTTP header value"
+        # — which fails EVERY response with a broken reply / 502 at the proxy.
+        ancestors = " ".join(settings.allowed_frame_ancestors.split())
+        if not ancestors:
+            return response
         response.headers["Content-Security-Policy"] = f"frame-ancestors 'self' {ancestors}"
         # X-Frame-Options only supports a single origin and is deprecated, but included
         # for older browser compatibility. Use the first origin from the list.
-        first_origin = ancestors.split()[0]
-        response.headers["X-Frame-Options"] = f"ALLOW-FROM {first_origin}"
+        response.headers["X-Frame-Options"] = f"ALLOW-FROM {ancestors.split()[0]}"
         return response
 
 # Concurrency control


### PR DESCRIPTION
## Symptom
In production the service **boots and listens fine** (`Uvicorn running on http://0.0.0.0:8080`), requests reach the app (`GET /?mode=embed 200`), but every response then crashes on send:

```
File ".../uvicorn/protocols/http/httptools_impl.py", line 500, in send
    raise RuntimeError("Invalid HTTP header value.")
RuntimeError: Invalid HTTP header value.
```

Net effect: the public URL returns **502** and the CRM's portrait-editor iframe won't load.

## Cause
The `frame_embedding_headers` middleware injected `ALLOWED_FRAME_ANCESTORS` **verbatim** into the `Content-Security-Policy` and `X-Frame-Options` response headers. When that env var carries a **trailing newline/whitespace** — very easy to introduce when pasting a URL into a hosting dashboard (Railway/Render/etc.) — the header value becomes illegal and uvicorn refuses to emit it, failing the whole response. The default `http://localhost:3000` is clean, so it only surfaces once a real domain is configured.

## Fix
- Collapse whitespace with `" ".join(value.split())` before building the header (strips leading/trailing and turns any newline/tab into a single space); skip the headers entirely if the result is empty.
- Defensively `.strip()` each `CORS_ORIGINS` entry so a pasted newline can't silently stop an allowed origin from matching.

Config-only, no behavior change for clean values.

## Note
Operators should still set the var to a clean value, e.g. `ALLOWED_FRAME_ANCESTORS=https://<crm-domain>` — this just makes a stray newline harmless instead of a full outage.

I couldn't run the repo's test suite in my sandbox (executing the freshly-cloned service was blocked), so please let CI validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)