### PR TITLE
feat(embed): receive contact portrait from CRM via postMessage

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -114,6 +114,19 @@ async def palettes():
     return {"palettes": list_palettes()}
 
 
+@app.get("/api/embed-config")
+async def embed_config():
+    """Origins allowed to embed/message the editor in embed mode.
+
+    Reuses the SAME allowlist that gates iframe embedding (CSP frame-ancestors /
+    ALLOWED_FRAME_ANCESTORS) so the embed page can validate inbound postMessage
+    event.origin against it. Normalized identically to the CSP middleware
+    (whitespace-split, empties dropped) so the two never disagree.
+    """
+    origins = settings.allowed_frame_ancestors.split() if settings.allowed_frame_ancestors else []
+    return {"allowedOrigins": origins}
+
+
 @app.post("/api/generate")
 async def generate(
     image: UploadFile = File(...),

--- a/static/index.html
+++ b/static/index.html
@@ -2303,6 +2303,81 @@ async function runBrowserPipeline(file) {
   browserSpinner.classList.remove('show');
 }
 
+// Load a finished pixel portrait straight into the editor as the current
+// editing image. Used by embed mode when the CRM hands us the contact's
+// existing portrait — it is ALREADY pixel art, so we skip face detection and
+// the whole generation pipeline and draw it directly.
+async function loadPortraitIntoEditor(dataUrl, { pixelated = true } = {}) {
+  const img = await new Promise((resolve, reject) => {
+    const im = new Image();
+    im.onload = () => resolve(im);
+    im.onerror = () => reject(new Error('Could not decode portrait image'));
+    im.src = dataUrl;
+  });
+
+  // The image's native resolution IS the pixel-art grid. Drive outputSize from
+  // it so the retouch brush / flood-fill / save all map pixels 1:1.
+  const nativeSize = img.naturalWidth || img.width;
+  if (!nativeSize) throw new Error('Portrait image has zero size');
+
+  const outputSel = document.getElementById('outputSize');
+  if (![...outputSel.options].some(o => o.value === String(nativeSize))) {
+    const opt = document.createElement('option');
+    opt.value = String(nativeSize);
+    opt.textContent = `${nativeSize} × ${nativeSize}`;
+    outputSel.appendChild(opt);
+  }
+  outputSel.value = String(nativeSize);
+
+  const scale = getSettings().scale;
+  const displaySize = nativeSize * scale;
+
+  // 1. Rasterize at native pixel-art resolution (1:1, alpha preserved).
+  const rawCanvas = document.createElement('canvas');
+  rawCanvas.width = nativeSize;
+  rawCanvas.height = nativeSize;
+  const rawCtx = rawCanvas.getContext('2d');
+  rawCtx.imageSmoothingEnabled = false;
+  rawCtx.drawImage(img, 0, 0, nativeSize, nativeSize);
+
+  // 2. Upscale into the display canvas. Honor pixelated:true → nearest-neighbor,
+  //    smoothing disabled, so the portrait stays crisp at every zoom.
+  browserCanvas.width = displaySize;
+  browserCanvas.height = displaySize;
+  const ctx = browserCanvas.getContext('2d');
+  ctx.imageSmoothingEnabled = !pixelated;
+  ctx.drawImage(rawCanvas, 0, 0, displaySize, displaySize);
+
+  // 3. Derive a retouch palette from the loaded pixels so the swatches work.
+  const palette = extractPalette(rawCtx.getImageData(0, 0, nativeSize, nativeSize));
+  clearBrush();
+  buildSwatches(document.getElementById('browserSwatches'), palette, 'rgb');
+
+  // 4. Editor state: this loaded image is the new baseline for undo/dirty.
+  //    currentFile stays null (no source photo) so settings changes don't try
+  //    to re-run the generation pipeline against a non-existent file.
+  currentFile = null;
+  detectedCrop = null;
+  cropControls.classList.remove('visible');
+  undoStack.length = 0;
+  redoStack.length = 0;
+  updateHistoryUI();
+
+  browserResult = browserCanvas;
+  browserDot.className = 'dot active';
+  document.getElementById('browserColorCount').textContent = palette.length;
+  document.getElementById('browserTime').textContent = 'Loaded';
+  updateExportSize();
+
+  setRetouchDirty(false);
+  storeAlgorithmSnapshot();
+  updateSaveEnabled();
+  updateFilenamePreview();
+
+  const saveBtn = document.getElementById('btnSavePortrait');
+  if (saveBtn) saveBtn.disabled = false;
+}
+
 // Download (current scale)
 btnDownload.addEventListener('click', () => {
   if (browserResult) {
@@ -2497,6 +2572,22 @@ function buildSwatches(container, palette, source) {
 function hexToRgb(hex) {
   const h = hex.replace('#', '');
   return [parseInt(h.substring(0,2), 16), parseInt(h.substring(2,4), 16), parseInt(h.substring(4,6), 16)];
+}
+
+// Collect the distinct opaque colors from image data — used to build the
+// retouch palette for a portrait loaded from outside the generation pipeline.
+function extractPalette(imageData, maxColors = 64) {
+  const seen = new Map();
+  const d = imageData.data;
+  for (let i = 0; i < d.length; i += 4) {
+    if (d[i + 3] === 0) continue; // skip fully-transparent pixels
+    const key = (d[i] << 16) | (d[i + 1] << 8) | d[i + 2];
+    if (!seen.has(key)) {
+      seen.set(key, [d[i], d[i + 1], d[i + 2]]);
+      if (seen.size >= maxColors) break;
+    }
+  }
+  return [...seen.values()];
 }
 
 
@@ -2856,15 +2947,93 @@ if (isEmbedMode) {
   });
   observer.observe(browserDot, { attributes: true, attributeFilter: ['class'] });
 
-  // Listen for init messages from parent
-  window.addEventListener('message', (e) => {
-    if (e.data && e.data.type === 'portrait-init') {
-      // Parent can send context (e.g., contact name for title)
-      if (e.data.contactName) {
-        document.title = `Portrait: ${e.data.contactName}`;
+  // ----------------------------------------------------------
+  // Inbound messages from the CRM (portrait-init / portrait-load)
+  // ----------------------------------------------------------
+  //
+  // The CRM posts to iframe.contentWindow right after the iframe's load event,
+  // with NO ready handshake — so the message listener MUST be live before then.
+  // It is registered synchronously below, during initial module execution,
+  // which completes before window 'load' fires.
+  //
+  // Origin trust reuses the SAME allowlist that gates iframe embedding
+  // (ALLOWED_FRAME_ANCESTORS / CSP frame-ancestors), fetched from the server.
+  // 'self' (location.origin) is always allowed so the editor can be driven
+  // same-origin (e.g. devtools). The allowlist loads asynchronously; any
+  // message that arrives before it is queued and replayed once it is known,
+  // so nothing is lost to the race.
+
+  let allowedOrigins = null;          // null = allowlist not loaded yet
+  const pendingMessages = [];
+
+  function isAllowedOrigin(origin) {
+    return Array.isArray(allowedOrigins) && allowedOrigins.includes(origin);
+  }
+
+  function handleEmbedMessage(event) {
+    const data = event.data;
+    if (data.type === 'portrait-init') {
+      if (data.contactName) {
+        document.title = `Portrait: ${data.contactName}`;
+        // Light touch: seed the file-organizer root name if the user hasn't set one.
+        const rootEl = document.getElementById('foRootName');
+        if (rootEl && !rootEl.value.trim()) {
+          rootEl.value = data.contactName.trim().replace(/[\/\\:*?"<>|]/g, '_') + '_portrait';
+          updateFilenamePreview();
+        }
+      }
+      // Best-effort readiness ping so a FUTURE CRM revision could gate its posts
+      // on it. The current CRM does not wait for this — do not depend on it.
+      try {
+        (event.source || window.parent).postMessage({ type: 'portrait-ready' }, event.origin);
+      } catch (_) { /* ignore — reply is best-effort */ }
+    } else if (data.type === 'portrait-load') {
+      if (typeof data.data === 'string' && /^data:image\//.test(data.data)) {
+        // pixelated defaults to true unless explicitly false.
+        loadPortraitIntoEditor(data.data, { pixelated: data.pixelated !== false })
+          .catch(err => console.error('[embed] Failed to load portrait:', err));
+      } else {
+        console.warn('[embed] portrait-load ignored: missing/invalid image data URL');
       }
     }
-  });
+  }
+
+  function onEmbedMessage(event) {
+    const data = event.data;
+    if (!data || typeof data !== 'object') return;
+    if (data.type !== 'portrait-init' && data.type !== 'portrait-load') return;
+
+    if (allowedOrigins === null) {
+      pendingMessages.push(event);   // allowlist not ready — replay later
+      return;
+    }
+    if (!isAllowedOrigin(event.origin)) {
+      console.warn('[embed] Ignoring message from disallowed origin:', event.origin);
+      return;
+    }
+    handleEmbedMessage(event);
+  }
+
+  // Register FIRST, synchronously — before any await / network work.
+  window.addEventListener('message', onEmbedMessage);
+
+  // Load the origin allowlist, then drain anything that arrived early.
+  fetch('/api/embed-config')
+    .then(r => r.json())
+    .then(cfg => {
+      allowedOrigins = [location.origin, ...(cfg.allowedOrigins || [])];
+    })
+    .catch(() => {
+      // Config unreachable — fall back to same-origin only (safe default).
+      allowedOrigins = [location.origin];
+    })
+    .finally(() => {
+      const queued = pendingMessages.splice(0);
+      for (const event of queued) {
+        if (isAllowedOrigin(event.origin)) handleEmbedMessage(event);
+        else console.warn('[embed] Ignoring queued message from disallowed origin:', event.origin);
+      }
+    });
 }
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,6 +39,24 @@ class TestPalettesEndpoint:
             assert "tags" in p
 
 
+class TestEmbedConfigEndpoint:
+    def test_returns_allowed_origins(self):
+        response = client.get("/api/embed-config")
+        assert response.status_code == 200
+        data = response.json()
+        assert "allowedOrigins" in data
+        assert isinstance(data["allowedOrigins"], list)
+
+    def test_origins_match_frame_ancestors_setting(self):
+        # The embed page validates inbound postMessage origins against this list,
+        # which must be the SAME allowlist that gates iframe embedding.
+        from app.config import settings
+
+        response = client.get("/api/embed-config")
+        expected = settings.allowed_frame_ancestors.split() if settings.allowed_frame_ancestors else []
+        assert response.json()["allowedOrigins"] == expected
+
+
 class TestGenerateEndpoint:
     def _make_test_image(self, width=256, height=256) -> bytes:
         """Create a simple test image."""


### PR DESCRIPTION
## What & why

The editor is embedded as an `<iframe>` in the WTFCRM app (`/?mode=embed`). The CRM was updated to hand the editor the contact's **existing** portrait so editing starts from the current image instead of a blank canvas — but this service didn't listen for it yet. This adds the receiving side.

### Contract (CRM → generator, posted on iframe `load`, no handshake)
- Always: `{ type: 'portrait-init', contactName }`
- If the contact has a custom portrait: `{ type: 'portrait-load', data: '<base64 PNG data URL>', pixelated: true }`

## Changes
- **`portrait-load`** → draws the base64 PNG straight onto the editor canvas as the current editing image. Skips face detection / the generation pipeline (it's already finished pixel art). Honors `pixelated: true` (nearest-neighbor, image smoothing off) and derives `outputSize` from the image so the retouch brush / flood-fill / save map pixels 1:1. Builds the retouch palette from the loaded pixels; resets undo/dirty to the loaded baseline.
- **`portrait-init`** → sets the title, seeds the filename field from `contactName`, and posts `{ type: 'portrait-ready' }` back (best-effort, so a future CRM revision *could* gate on it — current CRM doesn't).
- **Early listener** → the `message` listener is registered synchronously at embed startup, before `window` `load`, since the CRM posts on load with no ready handshake.
- **Origin validation** → reuses the *same* allowlist that gates iframe embedding (`ALLOWED_FRAME_ANCESTORS` / CSP `frame-ancestors`), newly exposed via `GET /api/embed-config`. `'self'` (same-origin) is always allowed; messages arriving before the allowlist loads are queued and replayed; disallowed origins are ignored. Mirrors the existing outbound `portrait-complete` / `portrait-cancel` pattern.

The existing frame-ancestor / port config is left fully intact — this only adds a read-only endpoint and client-side message handling.

## Verification
- **63/63** existing pytest tests pass; added 2 tests for `/api/embed-config`.
- End-to-end in headless Chromium (real `postMessage` flow):
  - `portrait-load` draws at 512×512 (64×8), correct quadrant colors, **crisp** hard edges (nearest-neighbor, no blend).
  - Editing works: selecting a palette swatch and painting repaints the targeted pixel-art cell, neighbors untouched.
  - `portrait-init` updates title, seeds filename, and the `portrait-ready` reply fires.
  - A message from a **disallowed origin** (opaque `null`) is ignored — canvas stays blank, Save stays disabled, warning logged.

## Deploy notes
- Merging to `main` triggers Railway auto-deploy.
- `NEXT_PUBLIC_PORTRAIT_GENERATOR_URL` in the CRM repo should already point at the generator's Railway domain (same service, same URL) — worth a confirm, no change expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)