### PR TITLE
fix(embed): stale-HTML caching + canonical-origin matching (portrait not loading)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -90,6 +90,22 @@ if settings.allowed_frame_ancestors:
         response.headers["X-Frame-Options"] = f"ALLOW-FROM {ancestors.split()[0]}"
         return response
 
+
+# Always revalidate HTML so browsers (and the CRM iframe) pick up new deploys
+# immediately. StaticFiles serves index.html with only Last-Modified/ETag and no
+# Cache-Control, which triggers heuristic caching — a browser can then treat a
+# cached copy as "fresh" for hours and never fetch the new embed code (symptom:
+# the iframe runs a stale index.html long after a deploy). "no-cache" still lets
+# the ETag produce a cheap 304 when nothing changed; it just forbids using the
+# cache without revalidating first.
+@app.middleware("http")
+async def html_revalidate_headers(request, call_next):
+    response = await call_next(request)
+    if response.headers.get("content-type", "").startswith("text/html"):
+        response.headers["Cache-Control"] = "no-cache"
+    return response
+
+
 # Concurrency control
 _semaphore = asyncio.Semaphore(settings.max_concurrent_requests)
 

--- a/static/index.html
+++ b/static/index.html
@@ -2966,8 +2966,18 @@ if (isEmbedMode) {
   let allowedOrigins = null;          // null = allowlist not loaded yet
   const pendingMessages = [];
 
+  // Compare origins the way browsers actually compare them — by canonical
+  // origin. event.origin is always a bare origin (no path, no trailing slash),
+  // but ALLOWED_FRAME_ANCESTORS is a hand-edited env var: a stray trailing
+  // slash / path / explicit default port there still lets the iframe load
+  // (browsers are lenient on frame-ancestors) yet would fail a raw string
+  // compare and silently drop every inbound message. Normalize both sides.
+  function normalizeOrigin(o) {
+    try { return new URL(o).origin; } catch (_) { return String(o).trim().replace(/\/+$/, ''); }
+  }
+
   function isAllowedOrigin(origin) {
-    return Array.isArray(allowedOrigins) && allowedOrigins.includes(origin);
+    return Array.isArray(allowedOrigins) && allowedOrigins.includes(normalizeOrigin(origin));
   }
 
   function handleEmbedMessage(event) {
@@ -2988,12 +2998,15 @@ if (isEmbedMode) {
         (event.source || window.parent).postMessage({ type: 'portrait-ready' }, event.origin);
       } catch (_) { /* ignore — reply is best-effort */ }
     } else if (data.type === 'portrait-load') {
-      if (typeof data.data === 'string' && /^data:image\//.test(data.data)) {
+      const src = data.data;
+      if (typeof src === 'string' && /^data:image\//i.test(src)) {
         // pixelated defaults to true unless explicitly false.
-        loadPortraitIntoEditor(data.data, { pixelated: data.pixelated !== false })
+        loadPortraitIntoEditor(src, { pixelated: data.pixelated !== false })
+          .then(() => console.info('[embed] portrait-load applied'))
           .catch(err => console.error('[embed] Failed to load portrait:', err));
       } else {
-        console.warn('[embed] portrait-load ignored: missing/invalid image data URL');
+        console.warn('[embed] portrait-load ignored — data is not an image data URL. typeof=%s prefix=%s',
+          typeof src, typeof src === 'string' ? src.slice(0, 40) : String(src));
       }
     }
   }
@@ -3008,7 +3021,7 @@ if (isEmbedMode) {
       return;
     }
     if (!isAllowedOrigin(event.origin)) {
-      console.warn('[embed] Ignoring message from disallowed origin:', event.origin);
+      console.warn('[embed] Ignoring message from disallowed origin:', event.origin, '— allowed:', allowedOrigins);
       return;
     }
     handleEmbedMessage(event);
@@ -3021,17 +3034,19 @@ if (isEmbedMode) {
   fetch('/api/embed-config')
     .then(r => r.json())
     .then(cfg => {
-      allowedOrigins = [location.origin, ...(cfg.allowedOrigins || [])];
+      allowedOrigins = [location.origin, ...(cfg.allowedOrigins || [])].map(normalizeOrigin);
+      console.info('[embed] message origin allowlist:', allowedOrigins);
     })
-    .catch(() => {
+    .catch((err) => {
       // Config unreachable — fall back to same-origin only (safe default).
-      allowedOrigins = [location.origin];
+      allowedOrigins = [normalizeOrigin(location.origin)];
+      console.warn('[embed] /api/embed-config unreachable — accepting same-origin only.', err);
     })
     .finally(() => {
       const queued = pendingMessages.splice(0);
       for (const event of queued) {
         if (isAllowedOrigin(event.origin)) handleEmbedMessage(event);
-        else console.warn('[embed] Ignoring queued message from disallowed origin:', event.origin);
+        else console.warn('[embed] Ignoring queued message from disallowed origin:', event.origin, '— allowed:', allowedOrigins);
       }
     });
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -57,6 +57,20 @@ class TestEmbedConfigEndpoint:
         assert response.json()["allowedOrigins"] == expected
 
 
+class TestHtmlCacheHeaders:
+    def test_html_sends_no_cache(self):
+        # The embed HTML must always revalidate, else browsers serve a stale
+        # index.html (and stale embed JS) for hours after a deploy.
+        response = client.get("/")
+        assert response.status_code == 200
+        assert "text/html" in response.headers.get("content-type", "")
+        assert response.headers.get("cache-control") == "no-cache"
+
+    def test_json_not_forced_no_cache(self):
+        response = client.get("/api/health")
+        assert response.headers.get("cache-control") != "no-cache"
+
+
 class TestGenerateEndpoint:
     def _make_test_image(self, width=256, height=256) -> bytes:
         """Create a simple test image."""


### PR DESCRIPTION
## Symptom
Loading an existing portrait in the embedded editor opens with **no image and no errors**.

## Root cause (two issues, one deploy)

### 1. Stale HTML cache — the actual reason it looked "not deployed"
`StaticFiles` serves `index.html` with only `Last-Modified`/`ETag` and **no `Cache-Control`**. Browsers then apply **heuristic caching** and can treat a cached copy as fresh for hours — so the CRM iframe kept running an *old* `index.html` (pre-embed-code) even though staging was already serving the new build. Confirmed by decoding the reporter's console line numbers (pre-PR#10 code) while `https://…-staging.up.railway.app/api/embed-config` already returned current JSON.

**Fix:** middleware sets `Cache-Control: no-cache` on `text/html` responses so browsers always revalidate (the existing `ETag` still yields cheap 304s). API/JSON responses unaffected. Frame-ancestors / CSP middleware left untouched.

### 2. Origin matching was too strict (defensive hardening)
Origin validation compared `event.origin` against the `ALLOWED_FRAME_ANCESTORS` allowlist by **exact string**. `event.origin` is a bare origin, but that env var can carry a trailing slash / path / explicit port — which still lets the iframe load yet silently drops every inbound message. (Staging's values happened to be clean, but this is a real trap.)

**Fix:** normalize both sides through `new URL().origin` before comparing, plus diagnostics — log the resolved allowlist, include it in rejection warnings, log `[embed] portrait-load applied`, and report the actual data shape when `portrait-load` data isn't an image URL.

## Verification
- `Cache-Control: no-cache` on HTML, absent on JSON; CSP intact (local + tests).
- True cross-origin repro in headless Chromium: trailing-slash allowlist dropped the message before, loads after; genuinely disallowed origin still rejected.
- Same-origin suite (16 checks incl. crisp render + real paint edit) + **65** pytest tests pass.

## Deploy notes
- Opening/updating this PR deploys to **staging**; merge to `main` ships production.
- Existing browsers holding a stale copy still need **one hard refresh** (Cmd+Shift+R) to pick up the no-cache header; after that they self-revalidate forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)